### PR TITLE
add bin/kiss to `files` for npm install --global

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "push"
   ],
   "files": [
-    "index.js"
+    "index.js",
+    "bin/kiss"
   ],
   "bin": "bin/kiss"
 }


### PR DESCRIPTION
when trying to install, it'll give ENOENT for bin/kiss because it's not in the list of files

cheers