### PR TITLE
firefox request will yield a 304, therefore body is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ Kiss.prototype.call = function* (context, next) {
   // try to serve the response
   let served = yield* this.serve(context, next)
   // push the dependencies if the response was served
-  if (served) yield* this.serveDependencies(context, next)
+  if (served && res.body) yield* this.serveDependencies(context, next)
 }
 
 /**


### PR DESCRIPTION
server will crash with firefox because the request to / will never retrieve the file, so body isn't defined to push dependencies...

I could check the status code but I figure in whatever case the body is empty or undefined, best to not try and parse it :)

cheers